### PR TITLE
Update Tuist configuration for new generation options API

### DIFF
--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,7 +1,12 @@
 import ProjectDescription
 
 let config = Config(
-  generationOptions: [
-    .resolveDependenciesWithSystemScm
-  ]
+  project: .tuist(
+    generationOptions: .options(
+      additionalPackageResolutionArguments: [
+        "-scmProvider",
+        "system"
+      ]
+    )
+  )
 )


### PR DESCRIPTION
## Summary
- switch the Tuist Config manifest to the newer project-based initializer
- replace the deprecated `resolveDependenciesWithSystemScm` option with the equivalent package resolution arguments

## Testing
- not run (tuist CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d0c7ed89f8832d9f1e23b88ee93746